### PR TITLE
Update docs with breaking change function name

### DIFF
--- a/content/docs/guides/02_relay_receive_send_messages.md
+++ b/content/docs/guides/02_relay_receive_send_messages.md
@@ -55,7 +55,7 @@ To ensure that you have relay peers available to send and receive messages,
 use the following function:
 
 ```js
-await waku.waitForConnectedPeer();
+await waku.waitForRemotePeer();
 ```
 
 The returned `Promise` will resolve once you are connected to a Waku Relay peer.

--- a/content/docs/guides/03_store_retrieve_messages.md
+++ b/content/docs/guides/03_store_retrieve_messages.md
@@ -69,7 +69,7 @@ To ensure that you have store peers available to retrieve historical messages fr
 use the following function:
 
 ```js
-await waku.waitForConnectedPeer();
+await waku.waitForRemotePeer();
 ```
 
 The returned Promise will resolve once you are connected to a Waku Store peer.

--- a/content/docs/guides/06_light_push_send_messages.md
+++ b/content/docs/guides/06_light_push_send_messages.md
@@ -69,7 +69,7 @@ To ensure that you have a light push peer available to send messages to,
 use the following function:
 
 ```js
-await waku.waitForConnectedPeer();
+await waku.waitForRemotePeer();
 ```
 
 The returned `Promise` will resolve once you are connected to a Waku peer.

--- a/content/docs/guides/07_reactjs_relay.md
+++ b/content/docs/guides/07_reactjs_relay.md
@@ -213,7 +213,7 @@ export default App;
 
 When using the `bootstrap` option, it may take some time to connect to other peers.
 To ensure that you have relay peers available to send and receive messages,
-use the `Waku.waitForConnectedPeer()` async function:
+use the `Waku.waitForRemotePeer()` async function:
 
 ```js
 React.useEffect(() => {
@@ -225,7 +225,7 @@ React.useEffect(() => {
   Waku.create({ bootstrap: { default: true } }).then((waku) => {
     setWaku(waku);
     setWakuStatus("Connecting");
-    waku.waitForConnectedPeer().then(() => {
+    waku.waitForRemotePeer().then(() => {
       setWakuStatus("Ready");
     });
   });

--- a/content/docs/guides/08_reactjs_store.md
+++ b/content/docs/guides/08_reactjs_store.md
@@ -239,7 +239,7 @@ export default App;
 
 When using the `bootstrap` option, it may take some time to connect to other peers.
 To ensure that you have store peers available to retrieve messages from,
-use the `Waku.waitForConnectedPeer()` async function:
+use the `Waku.waitForRemotePeer()` async function:
 
 ```js
 React.useEffect(() => {
@@ -247,7 +247,7 @@ React.useEffect(() => {
 
   if (wakuStatus === "Connected") return;
 
-  waku.waitForConnectedPeer().then(() => {
+  waku.waitForRemotePeer().then(() => {
     setWakuStatus("Connected");
   });
 }, [waku, wakuStatus]);
@@ -447,7 +447,7 @@ function App() {
 
     if (wakuStatus === "Connected") return;
 
-    waku.waitForConnectedPeer().then(() => {
+    waku.waitForRemotePeer().then(() => {
       setWakuStatus("Connected");
     });
   }, [waku, wakuStatus]);


### PR DESCRIPTION
Updated the docs to reflect the new breaking change introduced in v0.16.0
and the `waitForConnectedPeer` function was replaced with `waitForRemotePeer`.

[status.im/js-waku#511](https://github.com/status-im/js-waku/issues/511)