### PR TITLE
Mention create-waku-app

### DIFF
--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -12,6 +12,8 @@ We maintain a number of examples in the [waku-org/js-waku-examples](https://gith
 
 These examples use the latest published version of js-waku.
 
+Any example from the repository can be bootstrapped by helper package `@waku/app`. More details here: [README.md](https://github.com/waku-org/js-waku-examples/tree/master/create-waku-app)
+
 ## Community Examples
 
 Here are examples from the community.

--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -49,6 +49,10 @@ You can also try out some of the examples at the following locations:
 - [rln-js](https://examples.waku.org/rln-js): Demonstration of [RLN](https://rfc.vac.dev/spec/32/),
   an economic spam protection protocol that rate limit using zero-knowledge for privacy preserving purposes.
 
+If you want to play with examples, please, use one of the following commands to easily bootstrap an example:
+- `yarn create @waku/app <project-dir>`
+- `npx @waku/create-app <project-dir>`
+
 Finally, if you want to learn how Waku works under the hoods, check the specs at [rfc.vac.dev](https://rfc.vac.dev/).
 
 ## Bugs, Questions & Support


### PR DESCRIPTION
Added some text about option to use `@waku/app`
For the issue https://github.com/waku-org/js-waku-examples/issues/154